### PR TITLE
feat/publish-read-only-grants

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -78,15 +78,12 @@ models:
     publish:
       +schema: "publish_cost_reporting" # can be changed by users via src. overrides
       +docs: { node_color: "#DC143C" }
-      ### \/ uncomment to give reporter role read-only grants to the publish layer, off-scope on the package level
-      # +post-hook:
-      # - "grant usage on schema {{ this.database }}.{{ this.schema }} to role reporter_ft_{{ target.name|trim }}"
-      # - "grant select on {{ this }} to role reporter_ft_{{ target.name|trim }}"
-      ### /\ uncomment to give reporter role read-only grants to the publish layer, off-scope on the package level
+      +post-hook: "{{ grant_read_on_schema_objects() }}" # could also be managed via future grants
 
 vars:
-  dbt_cloud_account_id: 5235 # used on snowflake extras
-  dbt_cloud_run_url: "https://cloud.getdbt.com/deploy/" # used on snowflake extras, varies according to dbt cloud region
+  dbt_cloud_account_id: 5235 # used on sf extras
+  dbt_cloud_run_url: "https://cloud.getdbt.com/deploy/" # used on sf extras, depends on cloud region
   dbt_constraints_enabled: true
   fasttrack_cost_reporting_azure_tags_key: "ProjectName"
   fasttrack_cost_reporting_azure_tags_value: "Fast Track Development"
+  fasttrack_cost_reporting_read_roles: "reporter_ft" # comma-separated role prefixes ('' to disable)

--- a/macros/utils/grant_read_on_schema_objects.sql
+++ b/macros/utils/grant_read_on_schema_objects.sql
@@ -1,0 +1,21 @@
+{#-/*
+  helper macro for giving read-only grants on dbt-managed schema objects to a role
+*/-#}
+
+{% macro grant_read_on_schema_objects() -%}
+
+{%- set read_roles_var = var('fasttrack_cost_reporting_read_roles', 'reporter_ft') -%}
+{%- set role_suffix = '_' + target.name -%}
+
+{%- for role_prefix in read_roles_var.split(',') if role_prefix|length %}
+{%- set role_name = role_prefix + role_suffix -%}
+
+{%- set grant_query -%}
+grant usage on schema {{ this.database }}.{{ this.schema }} to role {{ role_name }};
+grant select on {{ this }} to role {{ role_name }};
+{%- endset -%}
+
+{% do run_query(grant_query) %}
+{%- endfor %}
+
+{%- endmacro %}


### PR DESCRIPTION
### Features
- add `grant_read_on_schema_objects` macro to give read-only grants (initially only on publish layer)
- add `fasttrack_cost_reporting_read_roles` var to control roles to be granted read-only access on publish by passing a comma-separated list of role prefixes that will receive `_{{ target.name }}` suffixes